### PR TITLE
メニュー項目を Build > Player に変更する

### DIFF
--- a/Assets/Scripts/Editor/ContinuousIntegration/Jenkins/BuildPackage.cs
+++ b/Assets/Scripts/Editor/ContinuousIntegration/Jenkins/BuildPackage.cs
@@ -5,7 +5,7 @@ using UnityModule.Settings;
 namespace ContinuousIntegration {
     public partial class Jenkins {
         public class BuildPackage : EditorWindow {
-            [MenuItem("Project/Build/Package/iOS")]
+            [MenuItem("Project/Build/Player/iOS")]
             public static void iOS() {
                 if (!IsValid()) {
                     return;
@@ -15,7 +15,7 @@ namespace ContinuousIntegration {
                 SendBuildRequest(BuildTarget.iOS);
             }
 
-            [MenuItem("Project/Build/Package/Android")]
+            [MenuItem("Project/Build/Player/Android")]
             public static void Android() {
                 if (!IsValid()) {
                     return;


### PR DESCRIPTION
## :eyes: 変更する理由

* 元々は、`Project > Build > Package > iOS` & `Project > Build > Package > Android` となっていた
* Unity においては、BuildPlayer という呼称の方が一般的なため、メニュー項目をリネームする

## 💪 やったこと

* `Project > Build > Player > iOS` or `Project > Build > Player > Android` にする